### PR TITLE
Bump Pillow to 12.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ matplotlib==3.2.1
 selenium==3.141.0
 webptools==0.0.2
 webdriver_manager==2.5.2
-Pillow==7.1.2
+Pillow==12.3.0


### PR DESCRIPTION
Updates Pillow from 7.1.2 to 12.3.0 to address CVE-2026-59200 reported by Dependabot.